### PR TITLE
Fix BCB reset on biscuit

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -54,7 +54,7 @@ def reset_bcb(dev, gpt):
     switch_user(dev)
     block = bytearray(dev.emmc_read(gpt["misc"][0] + 1))
     bcb_start = 0x160
-    block[bcb_start:bcb_start+7] = b'\x00\x41\x42\x42\x01\x8f\x8f'
+    block[bcb_start:bcb_start+7] = b'\x00\x41\x42\x42\x01\x8f\x00'
     dev.emmc_write(gpt["misc"][0] + 1, bytes(block))
 
 #NOTE: This doesn't actually wipe userdata, it just erases the first 10 blocks.


### PR DESCRIPTION
biscuit's preloader will reset the BCB metadata if two slots share conflicting priorities. The last 2 bytes contains the metadata for slot A / B, and 0x8f corresponds to prio=15 tries=0 success=1.

After running amonet, we can observe preloader resetting BCB as a result:

```
[3697] [BCB] metadata is not initialized or corrupted.
[3698] [BCB] create_default_metadata, default_active_slot = 0
[3698] [BCB] BCB Info: version 1
[3699] [BCB] Part 0 - prio=15 tries=3 success=0
[3699] [BCB] Part 1 - prio=14 tries=3 success=0
[3700] [BCB] BCB active slot = 0
[3706] [BCB] wrote BCB info to partition
[3708] [PART] partition hdr (1)
```

The defaults are quite dangerous since both slots have success=0, meaning there is no valid slot that preloader can fall back to if the tries counter runs out, which is quite likely to happen given that the current TWRP build also corrupts the BCB and non-FireOS systems will not set the success bit.

Set the last byte of the BCB metadata to zero to make preloader only consider slot A, which allows it to successfully parse the BCB:

```
[3761] [BCB] BCB Info: version 1
[3761] [BCB] Part 0 - prio=15 tries=0 success=1
[3762] [BCB] Part 1 - prio=0 tries=0 success=0
[3762] [BCB] BCB active slot = 0
```

Note that fixes in TWRP are required in addition to prevent that from corrupting the BCB, too.